### PR TITLE
Disable AP workarounds in DataInspector when `apply_access_policies` is off

### DIFF
--- a/shared/studio/state/connection.ts
+++ b/shared/studio/state/connection.ts
@@ -177,7 +177,6 @@ export class Connection extends Model({
   @computed
   get sessionConfig() {
     const sessionState = sessionStateCtx.get(this);
-    let config = {};
     if (sessionState === undefined) {
       return {}
     } else {

--- a/shared/studio/state/connection.ts
+++ b/shared/studio/state/connection.ts
@@ -174,6 +174,20 @@ export class Connection extends Model({
     return setQueryTag(state, "gel/ui");
   }
 
+  @computed
+  get sessionConfig() {
+    const sessionState = sessionStateCtx.get(this);
+    let config = {};
+    if (sessionState === undefined) {
+      return {}
+    } else {
+      return sessionState.activeState.config.reduce((configs, config) => {
+        configs[config.name] = config.value;
+        return configs;
+      }, {} as {[key: string]: any})
+    }
+  }
+
   query(
     query: string,
     params?: QueryParams,


### PR DESCRIPTION
The workaround query seems to be slow in 6 (regression?), so avoid it
when access policies are configured to be off.
