### PR TITLE
Keyboard (↑↓) support for type picker in DataExplorer view

### DIFF
--- a/shared/common/hooks/useKeyboardShortcut.ts
+++ b/shared/common/hooks/useKeyboardShortcut.ts
@@ -4,7 +4,7 @@ export function useKeyboardShortcut(key: string, callback: Function) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-      const isKeyPressed = event.key.toLowerCase() === key.toLowerCase();
+      const isKeyPressed = event.key === key;
 
       if (
         (isMac && event.metaKey && isKeyPressed) ||

--- a/shared/common/hooks/useKeyboardShortcut.ts
+++ b/shared/common/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,24 @@
+import {useEffect} from "react";
+
+export function useKeyboardShortcut(key: string, callback: Function) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+      const isKeyPressed = event.key.toLowerCase() === key.toLowerCase();
+
+      if (
+        (isMac && event.metaKey && isKeyPressed) ||
+        (!isMac && event.ctrlKey && isKeyPressed)
+      ) {
+        event.preventDefault();
+        callback();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [key, callback]);
+}

--- a/shared/common/ui/select/index.tsx
+++ b/shared/common/ui/select/index.tsx
@@ -7,6 +7,7 @@ import cn from "@edgedb/common/utils/classNames";
 
 import styles from "./select.module.scss";
 import {useIsMobile} from "../../hooks/useMobile";
+import {useKeyboardShortcut} from "../../hooks/useKeyboardShortcut";
 import {CrossIcon, DropdownIcon, SearchIcon, CheckIcon} from "../icons";
 
 export interface SelectItem<T = any> {
@@ -182,6 +183,8 @@ export function Select<T extends any>({
     }
   }, [dropdownOpen]);
 
+  useKeyboardShortcut("p", () => setDropdownOpen((prev) => !prev));
+
   function navigateFilter(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Escape") {
       return setDropdownOpen(false);
@@ -257,14 +260,19 @@ export function Select<T extends any>({
                   />
                 </div>
               ) : (
-                <input
-                  ref={searchRef}
-                  className={styles.searchInput}
-                  placeholder="Search..."
-                  value={searchFilter}
-                  onKeyDown={(e) => navigateFilter(e)}
-                  onChange={(e) => setSearchFilter(e.target.value)}
-                />
+                <span className={styles.searchInputWrapper}>
+                  <input
+                    ref={searchRef}
+                    className={styles.searchInput}
+                    placeholder="Search..."
+                    value={searchFilter}
+                    onKeyDown={(e) => navigateFilter(e)}
+                    onChange={(e) => setSearchFilter(e.target.value)}
+                  />
+                  <kbd className={styles.keyboardDiscovery}>
+                    <span className={styles.modifier}>⌘</span>P
+                  </kbd>
+                </span>
               ))}
             {items
               ? filteredItems

--- a/shared/common/ui/select/index.tsx
+++ b/shared/common/ui/select/index.tsx
@@ -192,6 +192,7 @@ export function Select<T extends any>({
       setDropdownOpen(false);
       return onChange?.(highlightedItem);
     } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+    e.preventDefault();
       const applicableList: SelectItem[] = filteredItems
         ? filteredItems.map((item) => item.obj.item.item)
         : (flattenedItems || [])
@@ -203,7 +204,7 @@ export function Select<T extends any>({
           (item) => item.id === prev?.id
         );
         return applicableList.at(
-          prevSelectedItemIndex + (e.key === "ArrowDown" ? 1 : -1)
+          (prevSelectedItemIndex + (e.key === "ArrowDown" ? 1 : -1)) % applicableList.length
         );
       });
     }

--- a/shared/common/ui/select/select.module.scss
+++ b/shared/common/ui/select/select.module.scss
@@ -195,7 +195,7 @@
     pointer-events: none;
   }
 
-  &:hover {
+  &.dropdownItemHighlighted {
     background: var(--app-accent-green);
     color: #fff;
 

--- a/shared/common/ui/select/select.module.scss
+++ b/shared/common/ui/select/select.module.scss
@@ -135,15 +135,21 @@
   }
 }
 
-.searchInput {
-  outline: 0;
-  border: 0;
-  background: #f2f2f2;
-  margin: 6px;
-  padding: 6px 8px;
+.searchInputWrapper {
+  display: flex;
   border-radius: 3px;
-  font-family: inherit;
-  color: inherit;
+  padding: 6px 8px;
+  margin: 6px;
+  background: #f2f2f2;
+
+  .searchInput {
+    flex-grow: 1;
+    outline: 0;
+    border: 0;
+    background: transparent;
+    font-family: inherit;
+    color: inherit;
+  }
 
   @include darkTheme {
     background: #1f1f1f;
@@ -250,5 +256,30 @@
 
   .dropdownItem {
     padding-right: 12px;
+  }
+}
+
+.keyboardDiscovery {
+  margin-left: 8px;
+  pointer-events: none;
+  display: inline-flex;
+  user-select: none;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0.375rem 0.5rem;
+  border-width: 1px;
+  border-radius: 4px;
+  gap: 0.25rem;
+  border: 1px solid #d9d9d9;
+  background: var(--form-field-bg);
+  opacity: 0.8;
+
+  @include darkTheme {
+    border-color: #141414;
+  }
+
+  .modifier {
+    font-size: 14px;
   }
 }


### PR DESCRIPTION
Hi Gel team, 
This is an attempt at fixing one of my biggest pet peeves using the Data Explorer (which I use a lot):
Support for keyboard events to enable selecting a type after searching for it in the dropdown without the mouse.

In addition, I've added listeners for the CMD+P/Ctrl+P shortcut (à la VSCode) to open this dropdown.

A few notes:

- "enter" selects the highlighted type
- "esc" closes the dropdown
- both mouse over and keyboard navigation handle the same highlighted item
- highlighted item is kept stable even if the list updates (because of search filtering)

Let me know if that works for you. I would love to see this or a similar idea implemented in the UI.
Best

![CleanShot 2025-04-08 at 23 23 57](https://github.com/user-attachments/assets/179ff611-5291-4a54-90d5-6ed5c2e54ee0)
