### PR TITLE
Fix dashboard causing queries to hang

### DIFF
--- a/shared/studio/components/modals/createBranch.tsx
+++ b/shared/studio/components/modals/createBranch.tsx
@@ -52,7 +52,7 @@ export default function CreateBranchModal({
 
   const onSubmit = handleSubmit(async ({branchName, fromBranch, copyData}) => {
     try {
-      await instanceState.defaultConnection?.query(
+      await instanceState.defaultConnection?.execute(
         legacy
           ? `create database \`${branchName}\``
           : fromBranch != null

--- a/shared/studio/tabs/dashboard/index.tsx
+++ b/shared/studio/tabs/dashboard/index.tsx
@@ -32,7 +32,7 @@ export const DatabaseDashboard = observer(function DatabaseDashboard() {
 
   useEffect(() => {
     if (dbState.schemaId != null) {
-      dbState.updateObjectCount();
+      return dbState.updateObjectCount();
     }
   }, [dbState.schemaId]);
 


### PR DESCRIPTION
The objects count query that the dashboard runs can be slow when the database contains a lot of objects, which blocks further queries in the UI until it's done. Since the object count on the dashboard is kind of just decorative we could get away with querying an approximate count, but we don't yet have a function for that: https://github.com/geldata/gel/issues/4164.

So instead cancel the count query when navigating away from the dashboard, and also add a connection pool to allow multiple simultaneous queries, as there's not really any reason to run most queries one at a time in the UI except for maybe schema introspection queries which some parts of the ui depend on to generate correct data fetching queries for example.