### PR TITLE
When running internal queries that ignore session config, set `apply_access_policies` config to false

### DIFF
--- a/shared/studio/state/connection.ts
+++ b/shared/studio/state/connection.ts
@@ -320,7 +320,12 @@ export class Connection extends Model({
       let state = this._state;
 
       if (opts.ignoreSessionConfig) {
-        state = setQueryTag(baseOptions.withGlobals(state.globals), "gel/ui");
+        state = setQueryTag(
+          baseOptions
+            .withConfig({apply_access_policies: false})
+            .withGlobals(state.globals),
+          "gel/ui"
+        );
       }
       if (opts.userQuery) {
         state = setQueryTag(state, "gel/webrepl");

--- a/shared/studio/state/connection.ts
+++ b/shared/studio/state/connection.ts
@@ -72,11 +72,18 @@ type QueryKind = "query" | "parse" | "execute";
 
 type QueryOpts = {
   newCodec?: boolean;
-  ignoreSessionConfig?: boolean;
   implicitLimit?: bigint;
-  userQuery?: boolean;
   blocking?: boolean;
-};
+} & (
+  | {
+      userQuery?: undefined;
+      ignoreSessionConfig?: boolean;
+    }
+  | {
+      userQuery?: boolean;
+      ignoreSessionConfig?: undefined;
+    }
+);
 
 type PendingQuery = {
   language: Language;


### PR DESCRIPTION
Without this the object count on the dashboard page will incorrectly show fewer objects than actually exist if they are hidden by default by access polices.