### PR TITLE
Don't group link counts by typename + limit to showing '100+' label

### DIFF
--- a/shared/common/components/dataGrid/state.ts
+++ b/shared/common/components/dataGrid/state.ts
@@ -1,6 +1,7 @@
 import {makeObservable, observable, computed, action} from "mobx";
 
 export const DefaultColumnWidth = 200;
+const minColWidth = 70;
 
 export interface GridColumn {
   id: string;
@@ -33,13 +34,13 @@ export class DataGridState {
 
   @action
   setColWidth(columnId: string, width: number) {
-    this._colWidths.set(columnId, Math.max(width, 60));
+    this._colWidths.set(columnId, Math.max(width, minColWidth));
   }
 
   @action
   setColWidths(widths: {[columnId: string]: number}) {
     for (const [id, width] of Object.entries(widths)) {
-      this._colWidths.set(id, Math.max(width, 60));
+      this._colWidths.set(id, Math.max(width, minColWidth));
     }
     this.onColumnResizeComplete?.(this._colWidths);
   }

--- a/shared/common/components/dataGrid/utils.ts
+++ b/shared/common/components/dataGrid/utils.ts
@@ -7,7 +7,7 @@ export function calculateInitialColWidths(
   let totalWidth = 0;
   for (const col of cols) {
     if (col.isLink) {
-      colWidths[col.id] = 280;
+      colWidths[col.id] = 180;
       continue;
     }
     const width = sizedColTypes[col.typename];

--- a/shared/studio/tabs/dataview/dataInspector.module.scss
+++ b/shared/studio/tabs/dataview/dataInspector.module.scss
@@ -277,9 +277,16 @@
 }
 
 .linksCell {
-  height: 39px;
-  display: flex;
-  align-items: center;
+  opacity: 0.8;
+  font-style: italic;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 8px;
+
+  span {
+    opacity: 0.8;
+  }
 }
 
 .editableCell {
@@ -379,51 +386,22 @@
   }
 }
 
-.linkObjName {
-  display: inline-flex;
-  flex-shrink: 0;
-  height: 24px;
-  line-height: 24px;
-  background: #e6e6e6;
-  border-radius: 12px;
-  color: #4d4d4d;
-  padding-left: 10px;
-  margin-right: 8px;
-  overflow: hidden;
-
-  span {
-    background: #d9d9d9;
-    margin-left: 8px;
-    padding: 0 10px 0 8px;
-  }
-
-  @include darkTheme {
-    background: #3d3d3d;
-    color: #adadad;
-
-    span {
-      background: #494949;
-    }
-  }
-}
-
-.linkCell:hover {
+.linkCell {
+  display: flex;
+  align-items: center;
   cursor: pointer;
 
-  .linkObjName {
-    background: #0ccb93;
-    color: var(--btn-text-hover);
+  svg {
+    margin-left: auto;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    opacity: 0.6;
+  }
 
-    span {
-      background: #0db181;
-    }
-
-    @include darkTheme {
-      background: #29b189;
-
-      span {
-        background: #049067;
-      }
+  &:hover {
+    svg {
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
https://geldata.slack.com/archives/C04BUK11UQ1/p1746820585759529?thread_ts=1746819833.796089&cid=C04BUK11UQ1

Grouping links by typename and then counting for every row seems to be slow for many links and/or when there are many link columns. So this PR simplifies link counts to just a total ungrouped count, and adds a limit to just show '100+' when there are more than 100 links.

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/8c89a138-684e-438f-92d7-7ce2dc3daaf7" />
