### PR TITLE
Add checkbox to Discord OAuth provider

### DIFF
--- a/shared/studio/tabs/auth/providers.tsx
+++ b/shared/studio/tabs/auth/providers.tsx
@@ -323,6 +323,33 @@ const DraftProviderConfigForm = observer(function DraftProviderConfigForm({
               onChange={(e) => draftState.setAdditionalScope(e.target.value)}
             />
           </div>
+          {draftState.selectedProviderType ===
+          "ext::auth::DiscordOAuthProvider" ? (
+            <>
+              <div className={styles.formRow}>
+                <Checkbox
+                  label={
+                    <>
+                      Always show consent form
+                      <InfoTooltip
+                        message={
+                          <>
+                            Whether the user is shown a consent form from the provider.
+                            Disabling this will still show the form when the user is new
+                            or when the requested scopes have been changed.
+                          </>
+                        }
+                      />
+                    </>
+                  }
+                  checked={draftState.alwaysShowConsentForm}
+                  onChange={(checked) =>
+                    draftState.setAlwaysShowConsentForm(checked)
+                  }
+                />
+              </div>
+            </>
+          ) : null}
         </>
       ) : providerKind === "Local" ? (
         <>

--- a/shared/studio/tabs/auth/state/index.tsx
+++ b/shared/studio/tabs/auth/state/index.tsx
@@ -1277,6 +1277,7 @@ export class DraftProviderConfig extends Model({
   oauthClientId: prop<string | null>(null).withSetter(),
   oauthSecret: prop<string | null>(null).withSetter(),
   additionalScope: prop("").withSetter(),
+  alwaysShowConsentForm: prop(true).withSetter(),
 
   providerName: prop<string | null>(null).withSetter(),
   displayName: prop<string | null>(null).withSetter(),
@@ -1462,6 +1463,13 @@ export class DraftProviderConfig extends Model({
             `display_name := ${JSON.stringify(this.displayName!.trim())}`,
             `issuer_url := ${JSON.stringify(this.issuerUrl!.trim())}`
           );
+          if (this.selectedProviderType === "ext::auth::DiscordOAuthProvider") {
+            queryFields.push(
+              `always_show_consent_form := ${
+                this.alwaysShowConsentForm ? "true" : "false"
+              }`
+            );
+          };
           if (this.logoUrl.trim()) {
             queryFields.push(
               `logo_url := ${JSON.stringify(this.logoUrl!.trim())}`


### PR DESCRIPTION
Linked with a [PR on the main `gel` project](https://github.com/geldata/gel/pull/8738).

Adds a checkbox when the Discord OAuth provider is selected that ask whether the user is always shown the discord consent form or only for new users or when scopes have changed.